### PR TITLE
Fix compatibility issue with Moodle book component

### DIFF
--- a/src/modules/download.ts
+++ b/src/modules/download.ts
@@ -326,10 +326,12 @@ export class DownloadManager extends EventEmitter {
                 try {
                     const stats = await fs.stat(absolutePath)
                     if (
-                        stats.mtime.getTime() / 1000 !== file.timemodified
-                        || stats.size !== file.filesize
+                        file.filesize !== 0 &&
+                        (stats.mtime.getTime() / 1000 !== file.timemodified
+                            || stats.size !== file.filesize)
                     ) {
-                        // if the file is there, but does not have the same size and last modified
+                        // if the file is there, the size on webeep is not 0 and 
+                        // it does not have the same size and last modified
                         // time as on webeep, download it again
                         file.updating = true
                         filesToDownload.push(file)

--- a/src/modules/download.ts
+++ b/src/modules/download.ts
@@ -326,9 +326,8 @@ export class DownloadManager extends EventEmitter {
                 try {
                     const stats = await fs.stat(absolutePath)
                     if (
-                        file.filesize !== 0 &&
-                        (stats.mtime.getTime() / 1000 !== file.timemodified
-                            || stats.size !== file.filesize)
+                        stats.mtime.getTime() / 1000 !== file.timemodified
+                        || (file.filesize !== 0 && stats.size !== file.filesize)
                     ) {
                         // if the file is there, the size on webeep is not 0 and 
                         // it does not have the same size and last modified


### PR DESCRIPTION
For some strange reason, HTML files inside a book component have their webeep file size property set to 0:
```json
{"type":"file","filename":"index.html","filepath":"/467/","filesize":0,"fileurl":"https://webeep.polimi.it/webservice/pluginfile.php/426763/mod_book/chapter/467/index.html","content":"Argomenti del corso.","timecreated":0,"timemodified":1662216028,"sortorder":0,"userid":null,"author":null,"license":null,"tags":[]}
```
 Because of this, since 0 is obviously different from the actual file size, the file gets downloaded on every sync event.

I don't know if this is the standard behaviour of HTML files located in a book module, but I think that the size property should be checked in order to verify that it isn't zero. This would prevent new downloads on every sync.