### PR TITLE
Handle files that were locally modified

### DIFF
--- a/src/modules/download.ts
+++ b/src/modules/download.ts
@@ -325,6 +325,10 @@ export class DownloadManager extends EventEmitter {
 
                 try {
                     const stats = await fs.stat(absolutePath)
+
+                    // if the local file is newer than the file on webeep, skip it
+                    if (stats.mtime.getTime() / 1000 > file.timemodified) continue
+
                     if (
                         stats.mtime.getTime() / 1000 !== file.timemodified
                         || (file.filesize !== 0 && stats.size !== file.filesize)


### PR DESCRIPTION
Hi, I'm here bothering you again to suggest a new feature 😄

Sometimes it happens that I edit a file, but as soon as a sync event occurs it is overwritten and all the changes are lost. It would be very useful to handle this situation properly.

A not perfect, but very quick solution would be to check if the local file is newer than the file located on webeep and if so just skip it. We may also add a specific setting to enable or disable this behavior.

Another option, but way more complicated would be to ask the user what to do, providing some options: 
- Overwrite the local file;
- Create a synced duplicate;
- Do not sync the file.

In addition, I think that  a "remember my choice" checkbox should be added.

Since this second solution would require a ton of work, I think we could implement the former and maybe work on the latter in the future