### PR TITLE
Write downloaded files directly to disk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,6 @@ const { debug, log, error } = createLogger("APP")
 
 const DEV = process.argv.includes("--dev")
 
-// Increase the max heap size
-app.commandLine.appendSwitch("js-flags", "--max-old-space-size=4096")
-
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
   // eslint-disable-line global-require

--- a/src/modules/download.ts
+++ b/src/modules/download.ts
@@ -205,9 +205,14 @@ export class DownloadManager extends EventEmitter {
             new Date(file.timemodified * 1000)
           )
         } catch (e) {
-          if (e.name === "AbortError") {
-            debug(`Cancelled request for file ${fullpath}`)
-            return
+          switch (e.name) {
+            case "AbortError":
+              debug(`Cancelled request for file ${fullpath}`)
+              throw e
+            case "RequestError":
+            case "HTTPError":
+            case "TimeoutError":
+              throw e
           }
 
           if (e.code === "EISDIR") {
@@ -280,6 +285,7 @@ export class DownloadManager extends EventEmitter {
       this.cancelAllRequests()
       switch (e.name) {
         case "CancelError":
+        case "AbortError":
           return SyncResult.stopped
 
         case "RequestError":


### PR DESCRIPTION
Avoids storing temporarily in memory, resolving issues with big-ish files.

I also removed the request object from currentDownloads in favor of just having a cancel function as otherwise node would give unhandled promises errors even tho everything is caught.

I've tested it with the course '085879 - TECNOLOGIE INFORMATICHE PER IL WEB [Semestre 2] (FRATERNALI PIERO) [2022-23]' which has a bunch of recordings (I think up to 100MBs) and it seems to be working fine.

I'm not super familiar with node so linting might be off.

(Btw I'm italian but all development seems to be in english, so pr is in english 🙊)