### PR TITLE
Fix: skip 404 missing files on download

### DIFF
--- a/src/modules/download.ts
+++ b/src/modules/download.ts
@@ -209,6 +209,21 @@ export class DownloadManager extends EventEmitter {
             new Date(file.timemodified * 1000),
           )
         } catch (e) {
+          // 404 error handling: skip missing files on the server
+          if (e.name === "HTTPError" && (e as any).response?.statusCode === 404) {
+            error(`Ignored missing file (404 Not Found): ${fullpath}`)
+
+            // remove the empty file that might have been created on disk
+            await fs.rm(absolutePath, { force: true }).catch(() => {}) 
+
+            // remove from current downloads and proceed with the next file
+            const idx = this.currentDownloads.indexOf(download)
+            if (idx !== -1) this.currentDownloads.splice(idx, 1)
+
+            if (files.length) await pushNewRequest()
+            return // exit gracefully without crashing the sync process
+          }
+
           switch (e.name) {
             case "AbortError":
               debug(`Cancelled request for file ${fullpath}`)


### PR DESCRIPTION
Ciao! Prima di tutto complimenti per questo tool, è davvero utile per noi studenti del Poli.

Dopo tre anni di utilizzo mi è capitato per la prima volta che l'app andasse in crash restituendo un networkError (HTTPError che porta a un SyncResult.networkError) e interrompendo l'intero processo di sincronizzazione.
Facendo un po' di debugging, ho scoperto che questo accade quando un professore elimina o nasconde un file su WeBeep (nel mio caso un README), ma l'API di Moodle continua a metterlo in lista. Quando l'app prova a scaricarlo, il server risponde con un errore 404 Not Found.

Ho aggiunto un controllo nel blocco catch di download.ts per gestire questo specifico HTTPError. In presenza di un errore 404, il file viene ignorato e l'eventuale placeholder vuoto viene rimosso. Si passa al download successivo permettendo alla coda di concludersi con successo.

Ho testato la modifica in locale sul corso in questione e il sync prosegue senza intoppi.
Fammi sapere se va bene!