### PR TITLE
Workspace packages declared

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '.'
 allowBuilds:
   '@parcel/watcher': true
   electron: true


### PR DESCRIPTION
Should fix the github [action](https://github.com/toto04/webeep-sync/actions/runs/23515555809/job/68447021922) as well.
```
Run pnpm install --frozen-lockfile
 ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
Error: Process completed with exit code 1.
```